### PR TITLE
Update project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Python interpreted files
+*.pyc
+
+# Generated CA files
+src/ca/ca.cer
+src/ca/ca.key
+
+# The saved traffic and log
+db/*
+src/mallory.log

--- a/mallory_install.sh
+++ b/mallory_install.sh
@@ -1,147 +1,33 @@
 #!/bin/bash
-# ----------------------------------------------------------------
-# This script updates a basic installation of Ubuntu (10.10 or 11.04)
-# to the latest package revs, and installs the packages required
-# to run the current (1.0) version of the Mallory tool.
-# ----------------------------------------------------------------
-# Copyright 2011 - Intrepidus Group
-# ----------------------------------------------------------------
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# ----------------------------------------------------------------
+echo -e "Latest supported Debian-based releases are Ubuntu 18.04 (Bionic) or Debian 10 (Buster).\nOnly Python 2 is supported.\nThis script assumes the use of apt package manager.\nIt is recommended to install mallory in a virtual machine.\nThis script was tested on ubuntu; there may be a variance in package names between distributions."
+echo
+echo "The script will now install/update dependencies using apt and pip. (safe to rerun)"
+read -p "Press any key to continue, or ctrl+c to exit: " -n 1 -r
+echo 
 
 set -e
-export UPDATE_DIR=${HOME}/.mallory/update
-export UPDATE_LOG=${UPDATE_DIR}/update.log
+set -x
+sudo apt-get update
 
-# -----------------------------------------------------------------
-# functions
-# -----------------------------------------------------------------
-function print_header {
-  echo "+--------------------------------------------------------+"
-  echo "|           MALLORY  INSTALL/UPDATE  SCRIPT              |"
-  echo "+--------------------------------------------------------+"
-}
+sudo apt-get install build-essential libnetfilter-conntrack-dev git python-pip python-m2crypto python-qt4 pyro-gui python-netfilter python-pyasn1 python-pil python-ipy python-paramiko python-twisted-web python-qt4-sql libqt4-sql-sqlite sqlite3 python  --no-install-recommends
 
-function phase0 {
-  # create the update directory if it doesn't exist
-  mkdir -p ${UPDATE_DIR}
-  print_header
-  echo "| Before running this script, please ensure that you've  |"
-  echo "|  configured a network interface and that the internet  |"
-  echo "|         is reachable by this virtual machine.          |"
-  echo "+--------------------------------------------------------+"
-  echo "| Once you have done this (or if you already had) simply |"
-  echo "|        rerun this script to continue the update        |"
-  echo "+--------------------------------------------------------+"
-  echo "phase1" > ${UPDATE_DIR}/.next_phase
-  exit 0
-}
+sudo -H pip2 install pynetfilter_conntrack
+set +x
 
-function phase1 {
-  print_header
-  echo "beginning Mallory installation"
-  echo "updating apt package list"
-  sudo apt-get update |tee ${UPDATE_LOG}
-  echo ""
-
-  echo "upgrading OS to latest versions of installed packages"
-  sudo apt-get upgrade -y |tee -a ${UPDATE_LOG}
-
-  echo "installing Mallory dependencies"
-  sudo apt-get -y install build-essential libnetfilter-conntrack-dev libnetfilter-conntrack3 |tee -a ${UPDATE_LOG}
-  if [ ! -f /usr/lib/netfilter_conntrack.so.1 ]; then
-    sudo ln -s /usr/lib/libnetfilter_conntrack.so /usr/lib/libnetfilter_conntrack.so.1
-  fi
-  sudo apt-get -y install python-pip git python-m2crypto python-qt4 pyro-gui python-netfilter python-pyasn1 python-pil python-ipy|tee -a ${UPDATE_LOG}
-  sudo apt-get -y install python-paramiko python-twisted-web python-qt4-sql libqt4-sql-sqlite sqlite3 |tee -a ${UPDATE_LOG}
-  sudo pip install pynetfilter_conntrack
-  echo ""
-
-  echo "enter directory you'd like Mallory to be installed to"
-  read -p "(default: ${HOME}/mallory)" mallorydir
-
-  if [ "$mallorydir" == "" ]; then
-    mallorydir="${HOME}/mallory";
-  fi
-  mkdir -p $mallorydir
-  echo ${mallorydir} > ${UPDATE_DIR}/installdir
-  echo "retrieving current mallory source from bitbucket"
-  /usr/bin/git clone https://github.com/intrepidusgroup/mallory ${mallorydir}/current
-
-  echo "phase2" > ${UPDATE_DIR}/.next_phase
-  phase2
-}
-
-
-function phase2 {
-  print_header
-  echo "Mallory installation completed"
-  echo "To use mallory:"
-  echo "Open a new terminal window, cd to ${mallorydir}/current/src, then run:"
-  echo "  sudo python ./mallory.py"
-  echo ""
-  echo "To run the mallory GUI:"
-  echo "Open a new terminal window cd to ${mallorydir}/current/src and run:"
-  echo "  sudo chown $USER mallory.log"
-  echo " where $USER is the user you are logged in as. Then run:"
-  echo "  python ./launchgui.py"
-  echo "Have fun!"
-  read -n1 -p "press any key to continue..."
-
-  echo "update" > ${UPDATE_DIR}/.next_phase
-  exit 0
-}
-
-function update {
-  echo 'Please cd into ${mallorydir}/current and update manually with "git pull"'
-  echo "If you want to rerun this script please clean ~/.mallory/update"
-  exit 0
-}
-
-
-# -----------------------------------------------------------------
-# scriptybits
-# -----------------------------------------------------------------
-
-if [[ -f ${UPDATE_DIR}/.next_phase ]]; then
-  case `cat ${UPDATE_DIR}/.next_phase` in
-    phase0)
-      phase0
-    ;;
-
-    phase1)
-      phase1
-    ;;
-
-    phase2)
-      phase2
-    ;;
-
-    update)
-      update
-    ;;
-
-    phase4)
-      echo "phase4: profit!"
-      exit 0
-    ;;
-
-    *)
-      echo "unknown update status, attempting update"
-      update
-    ;;
-  esac
-else
-  phase0
-fi
+echo
+echo 'Installation complete.'
+echo 
+echo "If you haven't already, install the Mallory repo by running in a directory of your choosing:"
+echo 
+echo "    /usr/bin/git clone https://github.com/Tokarak/mallory"
+echo 
+echo 'In the repo, src/mallory.py has the core functionality of mallory. src/launchgui.py can launch the gui WHILE src/mallory.py is already running.'
+echo 'It is recommended to run the gui on your virtual machine using ssh with X11 forwarding (ssh -X ...) instead of installing a bulky desktop. To enable X11forwarding on your VM:'
+echo "    sudo apt install xauth"
+echo 'Search "X11Forwarding" online to learn more.'
+echo
+echo 'Notice: if you get a "cannot open shared object file" error on running the script, please see:'
+echo 'https://web.archive.org/web/20131007182424/http://intrepidusgroup.com/insight/2013/07/getting-mallory-to-run-in-modern-versions-of-ubuntu/'
+echo "Script end."
+echo
+exit 0

--- a/mallory_install.sh
+++ b/mallory_install.sh
@@ -63,9 +63,9 @@ function phase1 {
   if [ ! -f /usr/lib/netfilter_conntrack.so.1 ]; then
     sudo ln -s /usr/lib/libnetfilter_conntrack.so /usr/lib/libnetfilter_conntrack.so.1
   fi
-  sudo apt-get -y install python-pip git python-m2crypto python-qt4 pyro-gui python-netfilter python-pyasn1 |tee -a ${UPDATE_LOG}
+  sudo apt-get -y install python-pip git python-m2crypto python-qt4 pyro-gui python-netfilter python-pyasn1 python-pil python-ipy|tee -a ${UPDATE_LOG}
   sudo apt-get -y install python-paramiko python-twisted-web python-qt4-sql libqt4-sql-sqlite sqlite3 |tee -a ${UPDATE_LOG}
-  sudo pip install pynetfilter_conntrack IPy
+  sudo pip install pynetfilter_conntrack
   echo ""
 
   echo "enter directory you'd like Mallory to be installed to"

--- a/src/Pyro/protocol.py
+++ b/src/Pyro/protocol.py
@@ -268,7 +268,7 @@ class PYROAdapter(object):
 						raise ConnectionDeniedError('invalid response')
 			except socket.error:
 				Log.msg('PYROAdapter','connection failed to URI',str(URI))
-				raise ProtocolError('connection failed')
+				raise ProtocolError('Could not connect to mallory instance.')
 		finally:
 			self.lock.release()
 

--- a/src/config_if.py
+++ b/src/config_if.py
@@ -154,11 +154,12 @@ class ConfigInterfaces(object):
                           "%s -p tcp -m tcp --to-ports 20755") %  interface)
             cmds.append( ("iptables -t nat -A PREROUTING -j REDIRECT -i "
                           "%s -p udp -m udp --to-ports 20755") %  interface)
-            
-        for cmd in cmds:
-            subprocess.call(cmd, shell=True)
-        
+
         print cmds
+        for cmd in cmds:
+            subprocess.call(cmd, shell=True) # Better to fail explicitly on error
+        
+
     def __str__(self):
         return ("ifs:%s, mitm_ifs:%s, outbound_ifs:%s" 
                     % (self.interfaces, self.mitm_interfaces, 

--- a/src/gui/ProtocolsGui.py
+++ b/src/gui/ProtocolsGui.py
@@ -177,13 +177,11 @@ class ProtocolsTableModel(QtCore.QAbstractTableModel):
                 return str(proto.serverPort)
             
             if index.column() == PROTO_DEBUG:
-                debuggable = spacing + "No" + spacing
-                
-                if proto.__class__ == "TcpProtocol":
-                    debuggable = spacing + "Yes" + spacing
-                
-                return debuggable
-            
+                if isinstance( proto, TcpProtocol ):
+                    return spacing + "Yes" + spacing
+                else:
+                    return spacing + "No" + spacing
+
             return QtCore.QVariant()
 
         # Editing Data (Not Needed)

--- a/src/gui/guimain.py
+++ b/src/gui/guimain.py
@@ -195,7 +195,7 @@ class MalloryGui(QtGui.QMainWindow):
            
         eventcnt = 0
         while True:
-            try:
+            # try:
                 eventlist = self.remote_debugger.getdebugq()
                  
                 # Currently only handling one selection 
@@ -241,10 +241,10 @@ class MalloryGui(QtGui.QMainWindow):
                     #self.curdebugevent = next_unsent
                     self.send_cur_de(next_unsent)
                 
-            except:
-                print "[*] MalloryGui: check_for_de: exception in de check loop"
-                print sys.exc_info()
-                traceback.print_exc()
+            # except:
+            #     print "[*] MalloryGui: check_for_de: exception in de check loop"
+            #     print sys.exc_info()
+            #     traceback.print_exc()
          
 class StreamListDelegate(QtGui.QItemDelegate):
     def __init__(self, parent, model):

--- a/src/mallory.py
+++ b/src/mallory.py
@@ -101,11 +101,18 @@ from protocol import base, dnsp
 try:
     # These protocols have dependencies and may not be safe to import 
     from protocol import sslproto, http, ssh, https
-    from plugin_managers import http_plugin_manager
-except ImportError:
-    print "ImportError: Trouble importing protocols with dependencies. " \
+except ImportError, e:
+    print 'ImportError : "%s"' % e
+    print "Trouble importing protocols with dependencies. " \
             "Proceeding with minimal protocol support."
+    print "For support verify PIL (python-imaging) is installed"
 
+try:
+    from plugin_managers import http_plugin_manager
+except ImportError, e:
+    print 'ImportError : "%s"' % e
+    print "Could not import http_plugin_manager. " \
+            "Proceeding without support support."
 
 # Config object is global. Buyer beware.
 config = config.Config()
@@ -509,8 +516,9 @@ if __name__ == '__main__':
     opts = CmdLineOpts() 
     mallory = Mallory(opts)
     
-
-    mallory.add_plugin_manager(http_plugin_manager.HttpPluginManager())
+    if 'http_plugin_manager' in dir():
+        print "http_plugin_manager did not load, ignoring..."
+        mallory.add_plugin_manager(http_plugin_manager.HttpPluginManager()) 
     
     # Pull in the protocol configured on the command line for use with the
     # no-transparent option when the proxy is not being used transparently

--- a/src/mallory.py
+++ b/src/mallory.py
@@ -517,14 +517,14 @@ if __name__ == '__main__':
     mallory = Mallory(opts)
     
     if 'http_plugin_manager' in dir():
-        print "http_plugin_manager did not load, ignoring..."
+        mallory.log.info("Loading http_plugin_manager...")
         mallory.add_plugin_manager(http_plugin_manager.HttpPluginManager()) 
     
     # Pull in the protocol configured on the command line for use with the
     # no-transparent option when the proxy is not being used transparently
     if opts.options.proto:
         import protocol
-        print "Proto is %s" % (opts.options.proto)
+        mallory.log.info("Proto is %s" % (opts.options.proto))
         
         modulename,protoname = opts.options.proto.split(".")
             
@@ -536,7 +536,7 @@ if __name__ == '__main__':
                              "for port %d" \
                              % (protoinstance, protoinstance.serverPort))
         except:
-            print "Invalid protocol specified at command line"
+            mallory.log.warning("Invalid protocol specified at command line")
             
         
     mallory.main()

--- a/src/plugin_managers/plugin/image_flip.py
+++ b/src/plugin_managers/plugin/image_flip.py
@@ -1,5 +1,5 @@
 import config
-import Image
+from PIL import Image
 import StringIO
 from base import Base
 
@@ -20,11 +20,11 @@ class ImageFlip (Base):
                         pass
             kwargs['data'] = response
         return kwargs
-    
+
     def flip_image(self, imagein):
         outstr = ""
         outfile = StringIO.StringIO(outstr)
-        img = Image.open(StringIO.StringIO(imagein))                            
-        out = img.transpose(Image.ROTATE_180)                                                
+        img = Image.open(StringIO.StringIO(imagein))
+        out = img.transpose(Image.ROTATE_180)
         out.save(outfile, img.format)
         return outfile.getvalue()

--- a/src/plugin_managers/plugin/image_invert.py
+++ b/src/plugin_managers/plugin/image_invert.py
@@ -1,6 +1,6 @@
 import config
 from PIL import Image
-import ImageChops
+from PIL import ImageChops
 import StringIO
 from base import Base
 

--- a/src/plugin_managers/plugin/image_invert.py
+++ b/src/plugin_managers/plugin/image_invert.py
@@ -1,5 +1,5 @@
 import config
-import Image
+from PIL import Image
 import ImageChops
 import StringIO
 from base import Base
@@ -21,11 +21,11 @@ class ImageInvert (Base):
                         pass
             kwargs['data'] = response
         return kwargs
-    
+
     def invert_image(self, imagein):
         outstr = ""
         outfile = StringIO.StringIO(outstr)
-        img = Image.open(StringIO.StringIO(imagein))                            
-        out = ImageChops.invert(img)                                               
+        img = Image.open(StringIO.StringIO(imagein))
+        out = ImageChops.invert(img)
         out.save(outfile, img.format)
         return outfile.getvalue()

--- a/src/ruleconfig.py
+++ b/src/ruleconfig.py
@@ -26,12 +26,12 @@ userrules = [
  "direction":"c2s",
  "passthru":"True"
 },
-{
- "name":"FuzzS2C",
- "action":rule.Fuzz(bit_flip_percentage=45, bof_injection_percentage=100, bit_flip_density=12), 
- "direction":"s2c",
- "passthru":"True"
-},
+# {
+#  "name":"FuzzS2C",
+#  "action":rule.Fuzz(bit_flip_percentage=45, bof_injection_percentage=100, bit_flip_density=12),
+#  "direction":"s2c",
+#  "passthru":"True"
+# },
 {
  "name":"default",  
  "action":rule.Debug()

--- a/src/rules.ini
+++ b/src/rules.ini
@@ -68,3 +68,20 @@
 passthru=True
 action=Muck
 muck_1=A/B/g
+;
+ [DefaultFixGzip]
+ addr=*
+ port=*
+ direction=c2s
+ passthru=True
+ action=Muck
+ muck_1=gzip,deflate/ /1
+ muck_2=deflate/ /1
+ muck_3=gzip/ /1
+
+ [DefaultDebug]
+ addr=*
+ port=*
+ direction=*
+ passthru=False
+ action=Debug


### PR DESCRIPTION
With IntrepidusGroup mysteriously disappearing into thin air, the gitbucket mirror is down. This mainly updates those links to Github. Other changes include:

- stops at errors: much safer to run
- updating is prompted to be done manually through git
- changed old tools to new where possible (eg using pip)
- small optimisations and safety checks

I doubt this will get merged, so I urge anyone reading this to use my fork of the script instead of the one which will be cloned by git when you install.

It is better to use no script at all, as the install structure is somewhat messy; have a look at what apt installs in the file (don't forget the one line where pip is used), and clone this repo manually. This also allows you to find equivalent packages in other distributions (eg Arch).

The latest Ubuntu LTS (20.04 Focal at the time of writing) lacks some of the required packages. I managed to successfully install the dependencies on 18.04 Bionic. Check which packages are available on https://packages.ubuntu.com.